### PR TITLE
Added function for video hash

### DIFF
--- a/pHash.cpp
+++ b/pHash.cpp
@@ -18,6 +18,11 @@ ph_dct_imagehash_wrapper(const char *file) {
 	return hash;
 }
 
+ulong64* ph_dct_videohash_wrapper(const char *filename, int *l){
+	int &ll = *l;
+	return ph_dct_videohash(filename, ll);
+}
+
 // Magic; without it pHash fails to compute hashes for some PNG files (compiler or linker issue?)
 void
 magic() {
@@ -29,4 +34,3 @@ magic() {
 #ifdef __cplusplus
 }
 #endif
-

--- a/phash.go
+++ b/phash.go
@@ -26,9 +26,14 @@ typedef unsigned long long ulong64;
 ulong64 ph_dct_imagehash_wrapper(const char* file);
 int ph_hamming_distance(const ulong64 hash1,const ulong64 hash2);
 
+ulong64* ph_dct_videohash_wrapper(const char *filename, int *l);
+
 */
 import "C"
-import "unsafe"
+import (
+	"reflect"
+	"unsafe"
+)
 
 func init() {
 	C.cimg_exception_mode_quiet()
@@ -40,6 +45,28 @@ func ImageHashDCT(fn string) (uint64, error) {
 	defer C.free(unsafe.Pointer(cfn))
 	hash, err := C.ph_dct_imagehash_wrapper(cfn)
 	return uint64(hash), err
+}
+
+func VideoHash(fn string) ([]C.ulong64, error) {
+	cfn := C.CString(fn)
+	var l int
+
+	defer C.free(unsafe.Pointer(cfn))
+
+	array, err := C.ph_dct_videohash_wrapper(cfn, (*C.int)(unsafe.Pointer(&l)))
+	if err != nil {
+		return nil, err
+	}
+
+	length := l
+	hdr := reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(array)),
+		Len:  length,
+		Cap:  length,
+	}
+	goSlice := *(*[]C.ulong64)(unsafe.Pointer(&hdr))
+
+	return goSlice, err
 }
 
 // HammingDistance returns the Hamming distance between the two perceptual hashes.


### PR DESCRIPTION
Added function for video hash.

To be able to use it, use the patched version of pHash that solves problem with ffmpeg https://github.com/hszcg/pHash-0.9.6